### PR TITLE
Use prop-types package in prep for react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "node-pre-gyp": "^0.6.28",
     "postcss": "^5.0.21",
     "postcss-loader": "^0.8.2",
+    "prop-types": "^15.6.0",
     "react": "^15.0.2",
     "react-dom": "^15.3.2",
     "react-hot-loader": "^1.3.0",

--- a/src/jsondiff-for-react.js
+++ b/src/jsondiff-for-react.js
@@ -1,7 +1,8 @@
 /**
  * Created by guoguangyu on 2016/10/25.
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import jsondiffpatch from 'jsondiffpatch/src/main';
 import formatters from 'jsondiffpatch/src/main-formatters';
 


### PR DESCRIPTION
Use `prop-types` package as recommended by React: https://github.com/facebook/prop-types#prop-types.

This gets rid of the warning we see for upstream applications that depend on this:
<img width="657" alt="screen shot 2017-10-01 at 1 41 55 am" src="https://user-images.githubusercontent.com/4636740/31053069-c0701a04-a649-11e7-9b7c-733f6a634dbc.png">
